### PR TITLE
Fix throw response exception

### DIFF
--- a/libs/jd-client.js
+++ b/libs/jd-client.js
@@ -56,10 +56,10 @@ JDClient.prototype.execute = function(apiname, params) {
     }
     if (res['error_response']) {
       const error = res['error_response'];
-      return {
+      return Promise.reject({
         code: parseInt(error.code),
         message: error.zh_desc
-      };
+      });
     }
     const resp = res[field];
     return JSON.parse(resp.result);


### PR DESCRIPTION
问题：当请求京东联盟API返回异常，目前是包装了{code: xx, message: 'xxx' }作为正常返回给了SDK使用者。是否需要把异常作为Promise.reject明确返回给用户？
建议：给用户抛出异常。
修改前使用SDK
```javascript
let res = await client.execute('jd.union.open.order.query', {
  orderReq: {
    pageNo: 1,
    pageSize: 20,
    type: 1,
    time: '20200217160303'
  }
})
if (res.code === 0) {
  ...
} else {
  ...
}
```
修改后使用SDK
```javascript
try {
   let res = await client.execute('jd.union.open.order.query', {
       orderReq: {
         pageNo: 1,
         pageSize: 20,
         type: 1,
         time: '20200217160303'
     }
   })
} catch (error) {
  // 处理异常
  ...
}

```